### PR TITLE
테스트를 위한 예시 MCP Server 병합

### DIFF
--- a/app/server/math_server.py
+++ b/app/server/math_server.py
@@ -1,0 +1,42 @@
+# math_server.py
+from mcp.server.fastmcp import FastMCP
+
+# 이름으로 MCP 서버 초기화
+mcp = FastMCP(
+    "Math",  # Name of the MCP server
+    instructions="You are a Math assistant that can provide the current Math",  # Instructions for the LLM on how to use this tool
+    host="0.0.0.0",  # Host address (0.0.0.0 allows connections from any IP)
+    port=8005,  # Port number for the server
+)
+
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """두 숫자를 더합니다"""
+    print(f"Executing add({a}, {b})")  # 서버 측 로그
+    return a + b
+
+
+@mcp.tool()
+def multiply(a: int, b: int) -> int:
+    """두 숫자를 곱합니다"""
+    print(f"Executing multiply({a}, {b})")  # 서버 측 로그
+    return a * b
+
+
+# 예제 프롬프트 정의
+@mcp.prompt()
+def configure_assistant(skills: str) -> list[dict]:
+    """지정된 기술로 어시스턴트를 구성합니다."""
+    return [
+        {
+            "role": "assistant",  # AIMessage에 해당합니다
+            "content": f"당신은 유용한 어시스턴트입니다. 다음 기술을 보유하고 있습니다: {skills}. 항상 한 번에 하나의 도구만 사용하세요.",
+        }
+    ]
+
+
+if __name__ == "__main__":
+    # stdio 전송을 사용하여 서버 실행
+    print("Starting Math MCP server via stdio...")
+    mcp.run(transport="stdio")

--- a/app/server/time_server.py
+++ b/app/server/time_server.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from time import time
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+# Initialize FastMCP server with configuration
+mcp = FastMCP(
+    "TimeService",  # Name of the MCP server
+    instructions="You are a time assistant that can provide the current time for different timezones.",  # Instructions for the LLM on how to use this tool
+    host="0.0.0.0",  # Host address (0.0.0.0 allows connections from any IP)
+    port=8005,  # Port number for the server
+)
+
+
+@mcp.tool()
+async def get_current_time(timezone: Optional[str] = "Asia/Seoul") -> str:
+    """
+    Get current time information for the specified timezone.
+
+    This function returns the current system time for the requested timezone.
+
+    Args:
+        timezone (str, optional): The timezone to get current time for. Defaults to "Asia/Seoul".
+
+    Returns:
+        str: A string containing the current time information for the specified timezone
+    """
+    try:
+        # Get the timezone object
+        tz = time.timezone(timezone)
+
+        # Get current time in the specified timezone
+        current_time = datetime.now(tz)
+
+        # Format the time as a string
+        formatted_time = current_time.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+        return f"Current time in {timezone} is: {formatted_time}"
+    except time.exceptions.UnknownTimeZoneError:
+        return f"Error: Unknown timezone '{timezone}'. Please provide a valid timezone."
+    except Exception as e:
+        return f"Error getting time: {str(e)}"
+
+
+if __name__ == "__main__":
+    # Start the MCP server with stdio transport
+    # stdio transport allows the server to communicate with clients
+    # through standard input/output streams, making it suitable for
+    # local development and testing
+    mcp.run(transport="stdio")


### PR DESCRIPTION
본 PR은 feat/mcp-server 브랜치에서 작업된 테스트용 MCP Server 들을 main 브랜치로 병합하기 위함입니다.

**주요 구현 내용**
- **math_server.py:** 수학 계산을 위한 MCP 구현 추가
- **time_server.py:** timezone에 해당하는 시간 확인을 위한 MCP 구현 추가